### PR TITLE
French localization update.

### DIFF
--- a/lua/loc/fr.txt
+++ b/lua/loc/fr.txt
@@ -1,26 +1,51 @@
 {
 	"bm_w_akm_gold"   : "AKMS Dorée",
+  "bm_w_amcar"      : "Colt Modèle 733",
 	"bm_w_contraband" : "H&K HK417 avec M203 PI Lanceur de grenades",
 
+	"bm_w_r870"     : "Remington Modèle 870",
+  "bm_w_boot"     : "Winchester Modèle 1887",
+
+  "bm_w_x_chinchilla" : "Akimbo Smith & Wesson Modèle 29",
+  
 	"bm_w_gre_m79"          : "M79 Lanceur de grenades",
 	"bm_w_saw"              : "Scie OVE9000",
 	"bm_w_m32"              : "Milkor MGL Mk 1L Lanceur de grenades",
 	"bm_w_flamethrower_mk2" : "Lance-flammes",
 	"bm_w_long"             : "Arc Anglais",
 
+  "bm_w_mosin"          : "Carabine Mosin Nagant M1907",
+  "bm_w_winchester1874" : "Winchester Modèle 1873",
+  "bm_w_model70"        : "Winchester Modèle 70",
+
+	"bm_w_chinchilla"   : "Smith & Wesson Modèle 29",
+  
+  "bm_w_baka"     : "Micro Uzi IMI",
+
+  "bm_w_serbu"   : "Remington 870 à canon court",
+  
 	"bm_w_hunter" : "Amur Falcon Pistol Arbalète",
 	"bm_w_china"  : "China Lake Launcher",
 	"bm_w_ray"    : "M202 FLASH Lance-roquettes",
-
+    
 	"bm_wp_upg_o_eotech"        : "EOTech Modèle 553",
+  "bm_wp_upg_o_t1micro"       : "Aimpoint  Micro T-1 monté sur rail",
 	"bm_wp_upg_o_docter"        : "Viseur DOCTER II Plus",
 	"bm_wp_upg_o_eotech_xps"    : "EOTech Modèle EXPS3",
 	"bm_wp_upg_o_reflex"        : "Viseur Générique Open Reflex",
 	"bm_wp_upg_o_rx01"          : "Viseur Trijicon RX01 Polarized Reflex",
 	"bm_wp_upg_o_rx30"          : "Viseur Trijicon RX30 Reflex",
-	"bm_wp_fps_upg_o_45iron"    : "Viseur XTI Angle",
+  "bm_wp_upg_o_ak_scopemount" : "Monture optique K-VAR KV-045",
+  "bm_wp_fps_upg_o_45iron"    : "Monture d'angle XTI Angle",	
+  "bm_wpn_fps_upg_o_45rds_v2" : "Monture d'angle Aimpoint Micro T-2",
 	"bm_wp_upg_o_box"           : "Viseur Pulsar Digisight LRF N960 N970 nocturne avec chercheur de cibles",
+  "bm_wpg_o_mbus_rear"        : "Mires avant et arrière MBUS",
+  "bm_wp_upg_o_rmr"           : "Viseur Trijicon RM06 RMR",
+  "bm_wp_upg_o_spot"          : "Double Monture Optique avancée NcSTAR",
 
+  "bm_wp_m4_m_quick"    : "Magpul 5.56 NATO Original",
+	"bm_wp_sr2_m_quick"   : "Magpul 9mm Veresk Retrofit Original",
+  
 	"bm_wp_upg_o_sho_salvo_large"  : "Suppresseur SilencerCo Salvo 12",
 	"bm_wp_upg_ns_sho_salvo_large" : "Suppresseur SilencerCo Salvo 12",
 	"bm_wp_upg_ns_shot_thick"      : "Suppresseur Chigurh",
@@ -66,74 +91,235 @@
 	"bm_wp_upg_i_singlefire" : "Verouillage semi-automatique",
 	"bm_wp_upg_i_autofire"   : "Verrouillage automatique",
 
+	"bm_wp_mg42_b_mg34" : "Canon MG 34",
 	"bm_wp_mg42_b_vg38" : "Canon de fusil DLT-19 Heavy Blaster",
 
-	"bm_wp_famas_b_long"       : "Cannon civil G2",
-	"bm_wp_famas_b_short"      : "Cannon G2 Commando",
-	"bm_wp_famas_b_sniper"     : "Cannon G2 Sniper",
+  "bm_wp_ass_s552_fg_standard_green" : "Garde-main OD Green",
+  "bm_wp_ass_s552_fg_railed"         : "Garde-main à rail SIG SG 553",
+  "bm_wp_ass_s552_b_long"            : "Kit SIG SG 552 LB",
+
+  "bm_wp_aug_fg_a3"    : "Poignée avant AUG A3",
+	"bm_wp_aug_body_f90" : "Boite de culasse Thales EF88/F90",
+	"bm_wp_aug_b_short"  : "Canon 16 pouces  Carabine AUG",
+
+  "bm_wp_l85a2_fg_short" : "Poignée avant à rail Daniel Defense",
+  "bm_wp_l85a2_b_short"  : "Canon Prototype L22",
+
+  "bm_wp_famas_b_suppressed" : "Canon entièrement surpressé ",
+	"bm_wp_famas_b_long"       : "Canon civil G2",
+	"bm_wp_famas_b_short"      : "Canon G2 Commando",
+	"bm_wp_famas_b_sniper"     : "Canon G2 Sniper",
+  "bm_wp_famas_g_retro"      : "Poignée G2",
+
+  "bm_wp_ak5_fg_ak5c" : "Poignée avant Bofors AK 5C",
+  "bm_wp_ak5_fg_fnc"  : "Poignée avant FN FNC",
+  "bm_wp_ak5_b_short" : "Canon Bofors AK 5C",
+
+  "bm_wp_sub2000_fg_gen2"       : "Kit Gen 2",
+  "bm_wp_sub2000_fg_suppressed" : "Suppresseur GemTech MK-9K",
+  
+  "bm_wp_scar_b_short"         : "Kit Mk17 CQC",
+  "bm_wp_scar_b_long"          : "Kit Mk17 LB",
+  "bm_wp_scar_scar_fg_railext" : "Rail d'extension PWS SRX",
+  "bm_wp_scar_fg_railext"      : "Rail d'extension Primary Weapon Systems SRX",
 
 	"bm_wp_m14_body_ebr"         : "Chassis M1A SOPMOD",
 	"bm_wp_m14_body_jae"         : "Chassis Customisé JAE-100 G3",
 	"bm_wp_upg_o_m14_scopemount" : "Chassis Mk14",
 
-	"bm_wp_vhs_b_short" : "Cannon VHS-K2",
+	"bm_wp_vhs_b_short" : "Canon VHS-K2",
 
+  "bm_wp_upg_ass_m4_lower_reciever_core"		 : "Boite de culasse basse CORE15",
+	"bm_wp_m4_upper_reciever_edge"               : "Boite de culasse haute VLTOR MUR-1A",
+	"bm_wp_upg_ass_m4_upper_reciever_ballos"	 : "Boite de culasse haute 2A-Arms BALIOS-Lite",
+	"bm_wp_upg_ass_m4_upper_reciever_core"		 : "Boite de culasse haute CORE15",
+  
+  "bm_wp_m16_fg_vietnam"      : "Poignée avant M16A1",
 	"bm_wp_m4_uupg_b_long"      : "Kit de conversion .50 Beowulf",
 
-	"bm_wp_m4_uupg_b_sd"       : "Cannon AAC Honey Badger",
+  "bm_wp_m4_uupg_fg_lr300"   : "Poignée avant Z-M LR 300ML",
+	"bm_wp_upg_fg_jp"          : "Poignée avant JPHG3-1M en Fibre de Carbone",
+	"bm_wp_upg_fg_smr"         : "Pognée avant Geissele SMR MKIII",
+	"bm_wp_upg_ass_m4_fg_lvoa" : "Poignée avant customisée War Sport LVOA",
+	"bm_wp_upg_ass_m4_fg_moe"  : "Garde-main Magpul MOE SL",
+	"bm_wp_m4_uupg_b_sd"       : "Canon AAC Honey Badger",
 
-	"bm_wp_upg_ak_b_draco"       : "Cannon Draco Pistol",
-	"bm_wp_upg_ak_b_ak105"       : "Cannon AK-105 Barrel",
-	"bm_wp_upg_ass_ak_b_zastava" : "Cannon Zastava M76",
+  "bm_wp_upg_ak_b_draco"       : "Canon Romanian AIMR",
+	"bm_wp_upg_ak_b_ak105"       : "Canon AK-105",
+	"bm_wp_upg_ass_ak_b_zastava" : "Canon Zastava M76",
 
+	"bm_wp_ak_fg_combo2"       : "Monture optique Ultimak AK",
 	"bm_wp_ak_fg_combo3"       : "Rail modulaire Ultimak AK Forend System",
 	"bm_wp_upg_fg_midwest"     : "Rail Midwest Industries Quad",
+  "bm_wp_upg_ak_fg_krebs"    : "Poignée avant Krebs UFM Keymod System",
+  "bm_wp_upg_ak_fg_trax"     : "Poignée avant Strike Industries TRAX",
 	"bm_wp_saiga_fg_lowerrail" : "Multi-Rail Ultimak AK-47 Forend Custom Retrofit",
+  "bm_wp_saiga_fg_holy"      : "Système de rails Fuglystick, Pattern 'Cobra'",
 
-	"bm_wp_asval_b_proto" : "Cannon SR-3M",
-	"bm_wp_hk21_b_long" : "Cannon HK23E",
+  "bm_wp_upg_ak_g_hgrip" : "Poignée de pistolet Hogue OverMolded AK",
+  "bm_wp_upg_ak_g_pgrip" : "Poignée de pistolet US PALM Enhanced",
+  "bm_wp_upg_ak_g_wgrip" : "Poignée en bois",
+  "bm_wp_upg_ak_g_rk3"   : "Poignée de pistolet ZenitCo PK-3",
 
-	"bm_wp_polymer_barrel_precision" : "Barrel CRB Shroud",
+	"bm_wp_asval_b_proto" : "Canon SR-3M",
 
-	"bm_wp_sterling_b_e11"        : "Cannon de fusil E-11 Blaster",
-	"bm_wp_sterling_b_suppressed" : "Cannon Sterling L34A1",
-	"bm_wp_sterling_b_short"      : "Cannon Sterling Mk 7 \"Para-Pistol\"",
-	"bm_wp_sterling_m_short"      : "Cannon E-11 Blaster Rifle",
+  "bm_wp_polymer_barrel_precision" : "Canon CRB Shroud",
+    
+	"bm_wp_hk21_b_long" : "Canon HK23E",
+  
+	"bm_wp_uzi_b_suppressed" : "SIONICS \"Chuchotement Mortel\" Retrofit Custom",
 
-	"bm_wp_mp5_fg_mp5sd"      : "Cannon MP5SD5",
-	"bm_wp_mp5_fg_m5k"        : "Cannon MP5K-N",
-	"bm_wp_mp5_fg_flash"      : "Lampe LED Handguard with G&P CREE",
-	"bm_wp_mp5_m_straight"    : "Munition 10mm",
+  "bm_wp_cobray_ns_silencer" : "SIONICS \"Chuchotement Mortel\"",
+  "bm_wp_mac10_body_ris"     : "Kit de rail tactique G&P CQB Retrofit",
+  
+	"bm_wp_sterling_b_e11"        : "Canon de fusil E-11 Blaster",
+	"bm_wp_sterling_b_suppressed" : "Canon Sterling L34A1",
+	"bm_wp_sterling_b_short"      : "Canon Sterling Mk 7 \"Para-Pistol\"",
+	"bm_wp_sterling_m_short"      : "Chargeur E-11 Blaster Rifle",
+
+	"bm_wp_mp5_fg_mp5sd"      : "Canon MP5SD5",
+	"bm_wp_mp5_fg_m5k"        : "Canon MP5K-N",
+	"bm_wp_mp5_fg_flash"      : "Garde-main avec lampe LED G&P CREE",
+  "bm_wp_mp5_fg_flash_desc" : "Ce garde-main tactique est un replacement direct du garde-main avant du MP5.",
+	"bm_wp_mp5_m_straight"    : "Munitions 10mm",
 
 	"bm_wp_mp7_b_suppressed" : "Suppresseur H&K MP7 QD",
 
 	"bm_wp_mp9_b_suppressed" : "Suppresseur MP9 QD",
 
-	"bm_wp_p90_b_long"     : "Cannon civil PS90",
+	"bm_wp_p90_b_long"     : "Canon civil PS90",
+  "bm_wp_p90_b_civilian" : "Canon Moerse Lekker Sales Shroud",
 
-	"bm_wp_hajk_b_short" : "Cannon CZ 805 BREN A2",
+	"bm_wp_hajk_b_short" : "Canon CZ 805 BREN A2",
 
 	"bm_wp_scorpion_m_extended" : "Cartouche Quick-Swap",
+	"bm_wp_scorpion_g_wood"     : "Poignée en bois originale",
 
+  "bm_wp_pis_g_laser"      : "Poignée laser de Glock Crimson Trace",
+  "bm_wp_pis_g_beavertail" : "Poignée Cytec Beavertail",
+  
 	"bm_wp_beretta_co_co1"       : "Compensateur LA.RI.A AL-GI-MEC",
+  "bm_wp_beretta_g_ergo"       : "Poignée en bois",
+	"bm_wp_beretta_g_engraved"   : "Poignée engravée",
 
+  "bm_wp_c96_b_long"     : "Canon de carabine",
+	"bm_wp_c96_m_extended" : "Chargeur M72 Schnellfeuer",
+	"bm_wp_c96_nozzle"     : "Cache-flammes DL-44",
+	"bm_wp_c96_sight"      : "Viseur DL-44",
+  
+  "bm_wp_hs2000_sl_custom" : "Canon 4 pouces XD-9 V10",
+
+  "bm_wp_peacemaker_barrel_long" : "Canon spécial Buntline",
+  "bm_wp_peacemaker_barrel_short" : "Canon 5.5 pouces Colt SAA artillery",
+  
+  "bm_wp_sparrow_body_941" : "Kit Jericho 941 F",
+	"bm_wp_sparrow_g_cowboy" : "Chassis Jericho 941 R",
+        
 	"bm_wp_m95_b_barrel_suppressed" : "QDL Suppresseur + Camo Shroud",
+	"bm_wp_m95_b_barrel_long"       : "Canon Accuracy International AW50F",  
 
 	"bm_wp_upg_a_piercing_desc"       : "Une flechette est un projectile constitué d'une pointe métalique, avec un arrière pour stabiliser la trajectoire de la flechette.",
 	"bm_wp_upg_a_slug_desc"           : "Une chevrotine de fusil à pompe est un projectile lourd fait de plomb, cuivre, ou d'autre matériaux et est tiré par un fusil à pompe..\nUn chevrotine de fusil est habituellement plus importante qu'une balle de fusil.",
 	"bm_wp_upg_a_slug2_desc"          : "Une chevrotine de fusil à pompe est un projectile lourd fait de plomb, cuivre, ou d'autre matériaux et est tiré par un fusil à pompe..\nUn chevrotine de fusil est habituellement plus importante qu'une balle de fusil.",
 	"bm_wp_upg_a_dragons_breath_desc" : "Dragon's breath est un type spécial de chevrotine incendiaire pour les fusils à pompes de calibre 12. Les chevrotines Dragon's breath sont consistés en majorité de granulés de magnésium. Quand la chevrotine est tirée, éclats et flammes sont projetés jusqu'a une distance de 100 pieds.",
 
+  "bm_wp_basset_fg_short"   : "Canon raccourci et rail",
+	"bm_wp_basset_m_extended" : "Chargeur SGM Tactical SAIGA Shotgun 12 Round",
+
+  "bm_wp_ching_b_short"  : "Canon de Carabine T26",
+  "bm_wp_ching_fg_raied" : "Rail Fulton Armory Scout, Gen III",
+
+	"bm_wp_m1928_b_long" : "Canon Auto-Ordnance",
+  
+  "bm_wp_tec9_b_standard" : "Canon AB-10",
+	"bm_wp_tec9_ns_ext"     : "Canon étendu",
+  
+  "bm_wp_schakal_b_civil"     : "Canon USC",
+	"bm_wp_schakal_vg_surefire" : "Garde-main Surefire M900",
+	"bm_wp_schakal_ns_silencer" : "Suppresseur GemTech UMP-45",
+  
+  "bm_wp_g36_fg_c"    : "Garde-main G36C",
+  "bm_wp_g36_fg_ksk"  : "Garde-main Knight Armaments G36 RAS",
+  "bm_wp_g36_fg_long" : "Garde-main G36E",
+  "bm_wp_g36_m_quick" : "Chargeur G36 Magpul",
+  
+  "bm_wp_olympic_fg_railed" : "Poignée avant K23B Tactical",
+  
+  "bm_wp_fal_g_01"          : "Poignée SA58 OSW",
+  "bm_wp_fal_body_standard" : "Poignée avant SA58 OSW",
+  "bm_wp_fal_fg_03"         : "Poignée avant IMI Romat",
+  "bm_wp_fal_fg_04"         : "Poignée avant Sniper Customisé Imbel",
+  "bm_wp_fal_m_01"          : "Chargeur STANAG 40rnd",
+  
+  "bm_wp_galil_fg_sar"     : "Poignée avant Galil SAR",
+  "bm_wp_galil_fg_mar"     : "Poignée avant Galil MAR",
+  "bm_wp_galil_fg_fab"     : "Système de rail FAB Defense VFR-GA",
+  "bm_wp_galil_fg_sniper"  : "Poignée avant Galil 7.62",
+  
+  "bm_wp_g3_b_sniper"         : "Kit G3SG/1",
+  "bm_wp_g3_fg_psg"           : "Poignée avant MSG90",
+  "bm_wp_g3_fg_retro"         : "Poignée avant CETME",
+  "bm_wp_g3_fg_retro_plastic" : "Garde-main AK 4 Retrofit",
+  "bm_wp_g3_fg_railed"        : "Poignée avant avec rails",
+  
+  "bm_wp_aa12_barrel_long" : "Canon Régulier AA-12",
+  
+  "bm_wp_1911_g_ergo"   : "Poignée American Legend Pachmayr",
+  "bm_wp_1911_g_bling"  : "Poignée en bois",
+  
+  "bm_wp_m249_b_long" : "Canon M249-E2 SAW",
+  "bm_wp_m249_fg_mk46" : "Poignée avant MK46 Mod 0",
+  
+  "bm_wp_wa2000_b_long" : "Canon Gen 2",
+  
+  "bm_wp_desertfox_b_long"     : "Garde-main Early Quad-Rail",
+  "bm_wp_desertfox_b_silenced" : "Suppresseur DTSS .338",
+  
+  "bm_wp_tti_g_grippy" : "Poignée de pistolet Hogue OverMolded",
+  
+  "bm_wp_chinchilla_b_satan" : "Canon diabolique customisé Kokusai",
+  "bm_wp_chinchilla_g_black" : "Poignée synthétique",
+  
+  "bm_wp_breech_b_reinforced" : "Canon Sports Parabellum Mauser",
+  
+  "bm_wp_deagle_co_short" : "Compensateur Magnum Research DE50MB",
+  "bm_wp_deagle_co_long" : "Compensateur Boondock",
+  
+  "bm_wp_2006m_b_medium" : "Canon moyen",
+  "bm_wp_2006m_b_short"  : "Canon petit",
+  "bm_wp_2006m_b_long"   : "Canon lourd",
+  
+  "bm_wp_g26_b_custom"     : "Canon Salient Arms Tier 1",
+  "bm_wp_g26_m_custom"     : "Chargeur Salient Arms Tier 1",
+  "bm_wp_g26_body_salient" : "Chassis Salient Arms Tier 1",
+  
+  "bm_wp_b682_s_ammopouch" : "Porte-cartouches",
+  
+  "bm_wp_ben_b_short"     : "Canon M4 NFA",
+  
+  "bm_wp_ksg_b_short" : "Canon KSG-12 Tactical",
+  
+  "bm_wp_snp_msr_ns_suppressor" : "Supresseur TiTAN-QD .338 AAC",
+  
+  "bm_wp_mosin_b_short" : "Canon de Carabine M1907 M38",
+  "bm_wp_mosin_b_long"  : "Canon M1907's M91/30",
+  
+  "bm_wp_mosin_ns_bayonet_desc" : "La baïonnette Mosin Nagant est une baïonnette à pointe, ce qui signifie que contrairement à une baïonnette de type couteau, elle ne peut pas être maniée à la main.\nMesure 19 pouces et demi.",
+  
+	"bm_melee_bullseye"    : "Hachette S&W Bullseye",
 	"bm_melee_fairbair"    : "Couteau de combat Fairbairn-Sykes",
-	"bm_melee_taser"       : "Stun d'étourdissement ZAP 1M-Volt",
+	"bm_melee_taser"       : "Matraque électrique ZAP 1M-Volt",
 	"bm_melee_nin"         : "Pistolet à clous PALSODE IM360CI 90MM",
 	"bm_melee_kabar_tanto" : "Lame KA-BAR Tanto",
 	"bm_melee_ballistic"   : "Couteaux Ballistiques USA-Style",
 	"bm_melee_bayonet"     : "'60s AKM Bayonet de seconde génération",
 	"bm_melee_oldbaton"    : "Baton Monadnock PR-24",
-	"bm_melee_beardy"      : "Hache Nordic Long-Bearded",
-	"bm_melee_topaz"       : "Outil d'alpiniste Black Diamond Cobra",
+	"bm_melee_beardy"      : "Hache Nordique Long-Bearded",
+	"bm_melee_topaz"       : "Outil d'alpiniste Black Diamond Cobra",	
+  "bm_melee_wing"        : "Couteau Papillon",
 	"bm_melee_cs"          : "Tronçonneuse Homelite Super 2",
+  "bm_melee_rambo"       : "Couteau Bowie",
+  "bm_melee_x46"         : "Couteau utilitaire de survie Robson X46",
 
 	"bm_melee_weapon_info"        : "",
 	"bm_melee_fists_info"         : "",


### PR DESCRIPTION
THE TRANSLATION STILL GOT THINGS TO BE TRANSLATED/ LA TRADUCTION A ENCORE DES CHOSES À TRADUIRE

Here's a more updated version of the French translation, Due to myself now only playing on the VR version, and due to the BLT support being extremely glitchy according to me in VR, I don't use that mod anymore. 
Here are some points I want to address:
-I've fixed my typo with "Cannon" which is written with one N instead.
-As stated, I don't use that mod anymore, so I've might make some typo's that make the localization crash the game, before pushing it, I'll suggest to test it before. (If you remember, This already happened with my work on this mod)
-Decided to translate "Model" by the actual word in French which is "Modèle" beside the word is often used as the actual NAME of the weapon/attachment. If you aren't alright with this decision, feel free to delete those modified ones, If I'm not mistaking, I've only made that modification to those strings.
-I've tried to arrange the order of the strings in the same of the actual English localization, might be useless, but isn't for the next translators.
-I'm still not sure if "Boite de culasse" is the right translation for the receiver, Doesn't have any weapons at home, or any other users at the shooting range talking about any "receivers", "reçeuveur"(The word I've first thought it was supposed to be translated) or "boite de culasse". Didn't find much documentation on the internet to actually proof being the right translation, so feel free to not accept it.
-I've made some research for only a few weapons/attachments, so I might call a handguard as a grip and vice-versa, If someone wants to continue to translate this, I really suggest him/her/pancake make research than me.
-By moving some words orders (Because in french, we don't say "a FLYING banana" but "une banane VOLANTE", We need to arrange some words orders when translating from English), I've decided to move Carbine/carabine (Why do you not use the "correct" name ? I mean, it's a french name...Pff, stupid Americans) in the first position to for example, as a "MLGX23 Carbine Barrel" to precise what type of barrel it is, Translating in French as "Canon de Carabine MLGX23", which literally translate to "Carbine barrel type MLGX23", If needed, Simply move "Carabine" as where your "Carbine" was previously in the original English string, also, maybe remove the uppercase letter if needed for it, determine it was a "noun"/"type of weapon" instead of a random word.